### PR TITLE
Remove pysnirf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "lib/matlab/jsnirfy"]
 	path = lib/matlab/jsnirfy
 	url = https://github.com/fangq/jsnirfy.git
-[submodule "lib/python/pysnirf"]
-	path = lib/python/pysnirf
-	url = https://github.com/fNIRS/pysnirf.git
 [submodule "lib/matlab/snirf_homer3"]
 	path = lib/matlab/snirf_homer3
 	url = https://github.com/fNIRS/snirf_homer3.git

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ file in each package for instructions on how to use.
 | EasyH5 Toolbox | https://github.com/fangq/easyh5/archive/v0.8.tar.gz       |
 | JSNIRF Toolbox | https://github.com/fangq/jsnirfy/archive/v0.4.tar.gz      |
 | SNIRF_HOMER3   | https://github.com/fNIRS/snirf_homer3/archive/master.zip  |
-| pysnirf        | https://github.com/fNIRS/pysnirf/archive/master.zip       |
 
 [This page](https://github.com/BUNPC/Homer3/wiki/Standalone-SNIRF-loading-and-saving) provides examples of how to work with Snirf files using the [Homer3](https://github.com/BUNPC/Homer3) interface.
 


### PR DESCRIPTION
The pysnirf library does not comply with current SNIRF specifications. As such, it should be removed as it simply adds confusion for users. Of course it should be added back if it is updated.

To confirm the library is non compliant, you can search for the required terms `formatVersion` and `LengthUnit` in the repository and they do not exist. I have not done a comprehensive check of all missing or incorrect fields.