### PR TITLE
Remove python snirf validator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,3 @@
 [submodule "lib/matlab/snirf_homer3"]
 	path = lib/matlab/snirf_homer3
 	url = https://github.com/fNIRS/snirf_homer3.git
-[submodule "lib/python/python_snirf_validator"]
-	path = lib/python/python_snirf_validator
-	url = https://github.com/BUNPC/python_snirf_validator


### PR DESCRIPTION
The python snirf validator library does not comply with current SNIRF specifications. As such, it should be removed as it simply adds confusion for users. Of course it should be added back if it is updated.

To confirm the library is non compliant, you can search for the required term `LengthUnit` in the repository and it does not exist. I have not done a comprehensive check of all missing or incorrect fields.