### PR TITLE
Adjust formatting to match GitHub web editor

### DIFF
--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -152,19 +152,19 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 |            `detectorIndex`            | * Detector index for a given channel         |   `<i>`      * |
 |            `wavelengthIndex`          | * Wavelength index for a given channel       |   `<i>`      * |
 |            `wavelengthActual`         | * Actual wavelength for a given channel      |   `<f>`        |
-|            `wavelengthEmissionActual`| * Actual emission wavelength for a channel   |   `<f>`        |
+|            `wavelengthEmissionActual` | * Actual emission wavelength for a channel   |   `<f>`        |
 |            `dataType`                 | * Data type for a given channel              |   `<i>`      * |
 |            `dataTypeLabel`            | * Data type name for a given channel         |   `"s"`        |
 |            `dataTypeIndex`            | * Data type index for a given channel        |   `<i>`      * |
 |            `sourcePower`              | * Source power for a given channel           |   `<f>`        |
 |            `detectorGain`             | * Detector gain for a given channel          |   `<f>`        |
 |            `moduleIndex`              | * Index of the parent module (if modular)    |   `<i>`        |
-|            `sourceModuleIndex`       | * Index of the source's parent module        |   `<i>`        |
-|            `detectorModuleIndex`     | * Index of the detector's parent module     |   `<i>`        |
+|            `sourceModuleIndex`        | * Index of the source's parent module        |   `<i>`        |
+|            `detectorModuleIndex`      | * Index of the detector's parent module      |   `<i>`        |
 |     `stim{i}`                         | * Root-group for stimulus measurements       |   `{i}`        |
 |         `name`                        | * Name of the stimulus data                  |   `"s"`      + |
 |         `data`                        | * Data stream of the stimulus channel        |  `[<f>,...]` + |
-|         `dataLabels`                 | * Names of additional columns of stim data   |  `["s",...]`   |
+|         `dataLabels`                  | * Names of additional columns of stim data   |  `["s",...]`   |
 |     `probe`                           | * Root group for NIRS probe information      |   `{.}`      * |
 |         `wavelengths`                 | * List of wavelengths (in nm)                |  `[<f>,...]` * |
 |         `wavelengthsEmission`         | * List of emission wavelengths (in nm)       |  `[<f>,...]`   |

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -134,61 +134,61 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 
 |  SNIRF-formatted NIRS data structure  |            Meaning of the data               |     Type       |
 |---------------------------------------|----------------------------------------------|----------------|
-| `/formatVersion`                      | * SNIRF format version                       |   `"s"`      * |
-| `/nirs{i}`                            | * Root-group for 1 or more NIRS datasets     |   `{i}`      * |
-|     `metaDataTags`                    | * Root-group for metadata headers            |   `{.}`      * |
-|        `SubjectID`                    | * Subject identifier                         |   `"s"`      * |
-|        `MeasurementDate`              | * Date of the measurement                    |   `"s"`      * |
-|        `MeasurementTime`              | * Time of the measurement                    |   `"s"`      * |
-|        `LengthUnit`                   | * Length unit (case sensitive)               |   `"s"`      * |
-|        `TimeUnit`                     | * Time unit (case sensitive)                 |   `"s"`      * |
-|        `FrequencyUnit`                | * Frequency unit (case sensitive)            |   `"s"`      * |
-|         ...                           | * Additional user-defined metadata entries   |                |
-|     `data{i}`                         | * Root-group for 1 or more data blocks       |   `{i}`      * |
-|        `dataTimeSeries`               | * Time-varying signals from all channels     | `[[<f>,...]]`* |
-|        `time`                         | * Time (in `TimeUnit` defined in metaDataTag)|  `[<f>,...]` * |
-|        `measurementList{i}`           | * Per-channel source-detector information    |   `{i}`      * |
-|            `sourceIndex`              | * Source index for a given channel           |   `<i>`      * |
-|            `detectorIndex`            | * Detector index for a given channel         |   `<i>`      * |
-|            `wavelengthIndex`          | * Wavelength index for a given channel       |   `<i>`      * |
-|            `wavelengthActual`         | * Actual wavelength for a given channel      |   `<f>`        |
-|            `wavelengthEmissionActual`| * Actual emission wavelength for a channel   |   `<f>`        |
-|            `dataType`                 | * Data type for a given channel              |   `<i>`      * |
-|            `dataTypeLabel`            | * Data type name for a given channel         |   `"s"`        |
-|            `dataTypeIndex`            | * Data type index for a given channel        |   `<i>`      * |
-|            `sourcePower`              | * Source power for a given channel           |   `<f>`        |
-|            `detectorGain`             | * Detector gain for a given channel          |   `<f>`        |
-|            `moduleIndex`              | * Index of the parent module (if modular)    |   `<i>`        |
-|            `sourceModuleIndex`       | * Index of the source's parent module        |   `<i>`        |
-|            `detectorModuleIndex`     | * Index of the detector's parent module     |   `<i>`        |
-|     `stim{i}`                         | * Root-group for stimulus measurements       |   `{i}`        |
-|         `name`                        | * Name of the stimulus data                  |   `"s"`      + |
-|         `data`                        | * Data stream of the stimulus channel        |  `[<f>,...]` + |
-|         `dataLabels`                 | * Names of additional columns of stim data   |  `["s",...]`   |
-|     `probe`                           | * Root group for NIRS probe information      |   `{.}`      * |
-|         `wavelengths`                 | * List of wavelengths (in nm)                |  `[<f>,...]` * |
-|         `wavelengthsEmission`         | * List of emission wavelengths (in nm)       |  `[<f>,...]`   |
-|         `sourcePos2D`                 | * Source 2-D positions in `LengthUnit`       | `[[<f>,...]]`* |
-|         `sourcePos3D`                 | * Source 3-D positions in `LengthUnit`       | `[[<f>,...]]`  |
-|         `detectorPos2D`               | * Detector 2-D positions in `LengthUnit`     | `[[<f>,...]]`* |
-|         `detectorPos3D`               | * Detector 3-D positions in `LengthUnit`     | `[[<f>,...]]`  |
-|         `frequencies`                 | * Modulation frequency list                  |  `[<f>,...]`   |
-|         `timeDelays`                  | * Time delays for gated time-domain data     |  `[<f>,...]`   |
-|         `timeDelayWidths`             | * Time delay width for gated time-domain data|  `[<f>,...]`   |
-|         `momentOrders`                | * Moment orders of the moment TD data        |  `[<f>,...]`   |
-|         `correlationTimeDelays`       | * Time delays for DCS measurements           |  `[<f>,...]`   |
-|         `correlationTimeDelayWidths`  | * Time delay width for DCS measurements      |  `[<f>,...]`   |
-|         `sourceLabels`                | * String arrays specifying source names      |  `["s",...]`   |
-|         `detectorLabels`              | * String arrays specifying detector names    |  `["s",...]`   |
-|         `landmarkPos2D`               | * Anatomical landmark 2-D positions          | `[[<f>,...]]`  |
-|         `landmarkPos3D`               | * Anatomical landmark 3-D positions          | `[[<f>,...]]`  |
-|         `landmarkLabels`              | * String arrays specifying landmark names    |  `["s",...]`   |
-|         `useLocalIndex`               | * If source/detector index is within a module|   `<i>`        |
-|     `aux{i}`                          | * Root-group for auxiliary measurements      |   `{i}`        |
-|         `name`                        | * Name of the auxiliary channel              |   `"s"`      + |
-|         `dataTimeSeries`              | * Data acquired from the auxiliary channel   | `[[<f>,...]]`+ |
-|         `time`                        | * Time (in `TimeUnit`) for auxiliary data    |  `[<f>,...]` + |
-|         `timeOffset`                  | * Time offset of auxiliary channel data      |  `[<f>,...]`   |
+| `/formatVersion`                      | * SNIRF format version                       |   `"s"`      * |
+| `/nirs{i}`                            | * Root-group for 1 or more NIRS datasets     |   `{i}`      * |
+|     `metaDataTags`                    | * Root-group for metadata headers            |   `{.}`      * |
+|        `SubjectID`                    | * Subject identifier                         |   `"s"`      * |
+|        `MeasurementDate`              | * Date of the measurement                    |   `"s"`      * |
+|        `MeasurementTime`              | * Time of the measurement                    |   `"s"`      * |
+|        `LengthUnit`                   | * Length unit (case sensitive)               |   `"s"`      * |
+|        `TimeUnit`                     | * Time unit (case sensitive)                 |   `"s"`      * |
+|        `FrequencyUnit`                | * Frequency unit (case sensitive)            |   `"s"`      * |
+|         ...                           | * Additional user-defined metadata entries   |                |
+|     `data{i}`                         | * Root-group for 1 or more data blocks       |   `{i}`      * |
+|        `dataTimeSeries`               | * Time-varying signals from all channels     | `[[<f>,...]]`* |
+|        `time`                         | * Time (in `TimeUnit` defined in metaDataTag)|  `[<f>,...]` * |
+|        `measurementList{i}`           | * Per-channel source-detector information    |   `{i}`      * |
+|            `sourceIndex`              | * Source index for a given channel           |   `<i>`      * |
+|            `detectorIndex`            | * Detector index for a given channel         |   `<i>`      * |
+|            `wavelengthIndex`          | * Wavelength index for a given channel       |   `<i>`      * |
+|            `wavelengthActual`         | * Actual wavelength for a given channel      |   `<f>`        |
+|            `wavelengthEmissionActual`| * Actual emission wavelength for a channel   |   `<f>`        |
+|            `dataType`                 | * Data type for a given channel              |   `<i>`      * |
+|            `dataTypeLabel`            | * Data type name for a given channel         |   `"s"`        |
+|            `dataTypeIndex`            | * Data type index for a given channel        |   `<i>`      * |
+|            `sourcePower`              | * Source power for a given channel           |   `<f>`        |
+|            `detectorGain`             | * Detector gain for a given channel          |   `<f>`        |
+|            `moduleIndex`              | * Index of the parent module (if modular)    |   `<i>`        |
+|            `sourceModuleIndex`       | * Index of the source's parent module        |   `<i>`        |
+|            `detectorModuleIndex`     | * Index of the detector's parent module     |   `<i>`        |
+|     `stim{i}`                         | * Root-group for stimulus measurements       |   `{i}`        |
+|         `name`                        | * Name of the stimulus data                  |   `"s"`      + |
+|         `data`                        | * Data stream of the stimulus channel        |  `[<f>,...]` + |
+|         `dataLabels`                 | * Names of additional columns of stim data   |  `["s",...]`   |
+|     `probe`                           | * Root group for NIRS probe information      |   `{.}`      * |
+|         `wavelengths`                 | * List of wavelengths (in nm)                |  `[<f>,...]` * |
+|         `wavelengthsEmission`         | * List of emission wavelengths (in nm)       |  `[<f>,...]`   |
+|         `sourcePos2D`                 | * Source 2-D positions in `LengthUnit`       | `[[<f>,...]]`* |
+|         `sourcePos3D`                 | * Source 3-D positions in `LengthUnit`       | `[[<f>,...]]`  |
+|         `detectorPos2D`               | * Detector 2-D positions in `LengthUnit`     | `[[<f>,...]]`* |
+|         `detectorPos3D`               | * Detector 3-D positions in `LengthUnit`     | `[[<f>,...]]`  |
+|         `frequencies`                 | * Modulation frequency list                  |  `[<f>,...]`   |
+|         `timeDelays`                  | * Time delays for gated time-domain data     |  `[<f>,...]`   |
+|         `timeDelayWidths`             | * Time delay width for gated time-domain data|  `[<f>,...]`   |
+|         `momentOrders`                | * Moment orders of the moment TD data        |  `[<f>,...]`   |
+|         `correlationTimeDelays`       | * Time delays for DCS measurements           |  `[<f>,...]`   |
+|         `correlationTimeDelayWidths`  | * Time delay width for DCS measurements      |  `[<f>,...]`   |
+|         `sourceLabels`                | * String arrays specifying source names      |  `["s",...]`   |
+|         `detectorLabels`              | * String arrays specifying detector names    |  `["s",...]`   |
+|         `landmarkPos2D`               | * Anatomical landmark 2-D positions          | `[[<f>,...]]`  |
+|         `landmarkPos3D`               | * Anatomical landmark 3-D positions          | `[[<f>,...]]`  |
+|         `landmarkLabels`              | * String arrays specifying landmark names    |  `["s",...]`   |
+|         `useLocalIndex`               | * If source/detector index is within a module|   `<i>`        |
+|     `aux{i}`                          | * Root-group for auxiliary measurements      |   `{i}`        |
+|         `name`                        | * Name of the auxiliary channel              |   `"s"`      + |
+|         `dataTimeSeries`              | * Data acquired from the auxiliary channel   | `[[<f>,...]]`+ |
+|         `time`                        | * Time (in `TimeUnit`) for auxiliary data    |  `[<f>,...]` + |
+|         `timeOffset`                  | * Time offset of auxiliary channel data      |  `[<f>,...]`   |
 
 In the above table, the used notations are explained below
 
@@ -866,7 +866,7 @@ Chunked data is allowed to support real-time data streaming
 * **Type**:  numeric
 * **Location**: `/nirs(i)/aux(j)/timeOffset`
 
-This variable specifies the offset of the file time origin relative to absolute 
+This variable specifies the offset of the file time origin relative to absolute
 (clock) time in `TimeUnit` units.
 
 

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -152,19 +152,19 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 |            `detectorIndex`            | * Detector index for a given channel         |   `<i>`      * |
 |            `wavelengthIndex`          | * Wavelength index for a given channel       |   `<i>`      * |
 |            `wavelengthActual`         | * Actual wavelength for a given channel      |   `<f>`        |
-|            `wavelengthEmissionActual`| * Actual emission wavelength for a channel   |   `<f>`        |
+|            `wavelengthEmissionActual` | * Actual emission wavelength for a channel   |   `<f>`        |
 |            `dataType`                 | * Data type for a given channel              |   `<i>`      * |
 |            `dataTypeLabel`            | * Data type name for a given channel         |   `"s"`        |
 |            `dataTypeIndex`            | * Data type index for a given channel        |   `<i>`      * |
 |            `sourcePower`              | * Source power for a given channel           |   `<f>`        |
 |            `detectorGain`             | * Detector gain for a given channel          |   `<f>`        |
 |            `moduleIndex`              | * Index of the parent module (if modular)    |   `<i>`        |
-|            `sourceModuleIndex`       | * Index of the source's parent module        |   `<i>`        |
-|            `detectorModuleIndex`     | * Index of the detector's parent module     |   `<i>`        |
+|            `sourceModuleIndex`        | * Index of the source's parent module        |   `<i>`        |
+|            `detectorModuleIndex`      | * Index of the detector's parent module      |   `<i>`        |
 |     `stim{i}`                         | * Root-group for stimulus measurements       |   `{i}`        |
 |         `name`                        | * Name of the stimulus data                  |   `"s"`      + |
 |         `data`                        | * Data stream of the stimulus channel        |  `[<f>,...]` + |
-|         `dataLabels`                 | * Names of additional columns of stim data   |  `["s",...]`   |
+|         `dataLabels`                  | * Names of additional columns of stim data   |  `["s",...]`   |
 |     `probe`                           | * Root group for NIRS probe information      |   `{.}`      * |
 |         `wavelengths`                 | * List of wavelengths (in nm)                |  `[<f>,...]` * |
 |         `wavelengthsEmission`         | * List of emission wavelengths (in nm)       |  `[<f>,...]`   |


### PR DESCRIPTION
This PR was created by opening the file in the GitHub editor. Removing the extra space on line 869. GitHub then auto formatted the table.

Using the default GitHub formatting will mean people can make quick changes in the web editor, rather than having to clone and edit in local editor then push up.