### PR TITLE
Document release procedure

### DIFF
--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -34,6 +34,9 @@ subfolder
 BUNPC
 FieldTrip
 MNE
+ok
+mailchi
+ec
 NIRStorm
 Nirstorm
 fieldtriptoolbox

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+# SNIRF Release Procedure
+
+This document describes the process for releasing a new version of the SNIRF specification.
+Only someone with write access to the `fNIRS/snirf` repository can complete this procedure.
+
+1. Raise an issue at least one week prior to a planed release date to inform the community that a release is imminent.
+   Ensure that the issue clearly states the exact next proposed version number (e.g., `1.0`).
+2. Ensure at least one other admin (someone with write access) agrees with the planned release,
+   and confirms that there are no known blocking issues (open issues in the tracker are ok, but they should not be of critical nature). 
+   Approval should be provided as a comment in the issue, not via personal communication.
+3. Open a pull request that makes the following modifications:
+   1. Modify the version number in the opening lines of the specification to match the version to be released (e.g., `1.0`).
+4. Ensure at least one other admin approves the pull request, then it can be merged.
+5. Create a new release and git tag by:
+   1. Press the `Create a new release` button on the repository home page.
+   2. Click on the `Choose a tag` and type in the release version proceeded by a v, for example `v1.0`.
+   3. Set the release title to the same as the tag name.
+   4. Copy the dot points for this release from the CHANGELOG.md document to the release description field.
+   5. Hit `Publish release`
+6. Update the README.md document to reflect the new release by:
+   1. Change the path of the "View the most recent release version of the format" link to reflect the tagged version.
+      This will be something like https://github.com/fNIRS/snirf/blob/v1.0/snirf_specification.md
+7. Modify the specification document to indicate that it is now a development version by:
+   1. Increase the version number in the SNIRF specification and append the word "development" to it. E.g., `v1.1-development`.
+      This ensure that people can differentiate between released versions of the draft and work-in-progress versions.
+8. Send an email out on the mailing list via: https://mailchi.mp/89a906ec22cf/snirf
+9. Increase the version number listed on the Society for fNIRS website: https://fnirs.org/resources/software/snirf/


### PR DESCRIPTION
As discussed in #70 

@dboas @fangq @sstucker does this seem reasonable to you?

The main point I would like to push is 7.1.  
Currently when I visit the SNIRF specification I have no way to know if it is a released version or work in progress. So I may develop my software thinking it will be compatible with SNIRF, but I am targeting some shifting sand.  This isn't hypothetical, this is a confusion I have had.  
If we are going to use the word draft in the format string (not my preference, I'd rather just tag as 1.1 but @fangq did not approve this suggestion in #51) then we still add the word `development` to anything that isn't released to make it clear to users.


For the release naming I suggest using https://semver.org. So for example the release naming would go...
* `1.0.0` would be a released version
* Then between releases the snirf_specification.md document would be modified to contain the version string `1.0.1-development` making it clear to users that this is a working draft.
* `1.0.1` would then be released on some specific date for a small change (for example a spelling error or table formatting).
* Then between releases the snirf_specification.md document would contain the version string `1.0.2-development` 
* `1.1.0` would then be released for a new addition (for example a new optional field)
* Then between releases the snirf_specification.md document would contain the version string `1.1.1-development` 
* `2.0.0` would then be released for a breaking change such as changing the dimensions of a required array