### PR TITLE
Point to example data that is compatible with current specification

### DIFF
--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -86,6 +86,7 @@ Nasion
 SubjectID
 DCS
 mHz
+luke
 timecourse
 BFi
 Deoxygenated

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "samples"]
 	path = samples
-	url = https://github.com/fNIRS/snirf-samples.git
+	url = https://github.com/rob-luke/BIDS-NIRS-Tapping.git
 [submodule "lib/matlab/easyh5"]
 	path = lib/matlab/easyh5
 	url = https://github.com/fangq/easyh5.git

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ file in each package for instructions on how to use.
 
 | Submodule      |                               URL                         |
 |----------------|-----------------------------------------------------------|
-| sample data    | https://github.com/fNIRS/snirf-samples/archive/master.zip |
+| sample data    | https://github.com/rob-luke/BIDS-NIRS-Tapping             |
 | EasyH5 Toolbox | https://github.com/fangq/easyh5/archive/v0.8.tar.gz       |
 | JSNIRF Toolbox | https://github.com/fangq/jsnirfy/archive/v0.4.tar.gz      |
 | SNIRF_HOMER3   | https://github.com/fNIRS/snirf_homer3/archive/master.zip  |


### PR DESCRIPTION
The current version of SNIRF sample data is outdated and does not meet the current specification. This is misleading to new users and causes people to waste their time. It wastes time when developing software, but also for maintaining software, I keep getting help requests from users saying my software is wrong because they took the time to test it with the *official* sample data. 

This PR changes the example data to point to my repository of SNIRF files.

This is not ideal because its not maintained by the fNIRS GitHub account, also conflates the issue of BIDS, and the files are larger than I'd like for an example. But at least they are compliant with the specification. 

This is likely a temporary fix until the sample data is updated. But every day the wrong link is provided it wastes peoples time and will leave a negative taste for the project.