### PR TITLE
Added supported datatypes for processed TD moment data

### DIFF
--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -219,3 +219,7 @@ Wabnitz
 al
 et
 DTOF
+dMTF
+dSkew
+dVar
+skewness

--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -223,3 +223,4 @@ dMTF
 dSkew
 dVar
 skewness
+dMean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@
 
 **This version is in development and has not been released yet**
 
-* General clarification of wording throughout the specification
-* Remove sourcePos, detectorPos, and landmarkPos
-* Add wavelengthActual and wavelengthEmissionActual
-* Change stim/data names from attribute to regular dataset
+* General clarification of wording throughout the specification.
+* Remove sourcePos, detectorPos, and landmarkPos.
+* Add wavelengthActual and wavelengthEmissionActual.
+* Change stim/data names from attribute to regular dataset.
 * Require either 2D or 3D positions, not just 2D.
+* Require either 2D or 3D positions, not just 2D.
+* Add datatypes for processed TD moment data.
 
 
 ### `1.0 - Draft 3` (November 11 2019)
 
 [View this version](https://github.com/fNIRS/snirf/tree/da550abf7ec70084e31ba428df09a9dcbf3e6036)  
 
-* Initial version with change log
+* Initial version with change log.

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -902,7 +902,7 @@ This variable specifies the offset of the file time origin relative to absolute
 | Tag Name  |                           Meanings                               |
 |-----------|------------------------------------------------------------------|
 |"dOD"      | Change in optical density                                        |
-|"dMTF"     | Change in mean time-of-flight                                    |
+|"dMean"    | Change in mean time-of-flight                                    |
 |"dVar"     | Change in variance (2nd central moment)                          |
 |"dSkew"    | Change in skewness (3rd central moment)                          |
 |"mua"      | Absorption coefficient                                           |
@@ -914,7 +914,7 @@ This variable specifies the offset of the file time origin relative to absolute
 |"Lipid"    | Lipid concentration                                              |
 |"BFi"      | Blood flow index                                                 |
 |"HRF dOD"  | Hemodynamic response function for change in optical density      |
-|"HRF dMTF" | HRF for change in mean time-of-flight                            |
+|"HRF dMean"| HRF for change in mean time-of-flight                            |
 |"HRF dVar" | HRF for change in variance (2nd central moment)                  |
 |"HRF dSkew"| HRF for change in skewness (3rd central moment)                  |
 |"HRF HbO"  | Hemodynamic response function for oxyhemoglobin concentration    |

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -902,6 +902,9 @@ This variable specifies the offset of the file time origin relative to absolute
 | Tag Name  |                           Meanings                               |
 |-----------|------------------------------------------------------------------|
 |"dOD"      | Change in optical density                                        |
+|"dMTF"     | Change in mean time-of-flight                                    |
+|"dVar"     | Change in variance (2nd central moment)                          |
+|"dSkew"    | Change in skewness (3rd central moment)                          |
 |"mua"      | Absorption coefficient                                           |
 |"musp"     | Scattering coefficient                                           |
 |"HbO"      | Oxygenated hemoglobin (oxyhemoglobin) concentration              |
@@ -911,6 +914,9 @@ This variable specifies the offset of the file time origin relative to absolute
 |"Lipid"    | Lipid concentration                                              |
 |"BFi"      | Blood flow index                                                 |
 |"HRF dOD"  | Hemodynamic response function for change in optical density      |
+|"HRF dMTF" | HRF for change in mean time-of-flight                            |
+|"HRF dVar" | HRF for change in variance (2nd central moment)                  |
+|"HRF dSkew"| HRF for change in skewness (3rd central moment)                  |
 |"HRF HbO"  | Hemodynamic response function for oxyhemoglobin concentration    |
 |"HRF HbR"  | Hemodynamic response function for deoxyhemoglobin concentration  |
 |"HRF HbT"  | Hemodynamic response function for total hemoglobin concentration |


### PR DESCRIPTION
For time-domain moment data, it would useful to have a few more supported datatype strings codified