### PR TITLE
Remove snirf_homer3 submodule, add link to CONTRIBUTING.md in README

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "lib/matlab/jsnirfy"]
 	path = lib/matlab/jsnirfy
 	url = https://github.com/fangq/jsnirfy.git
-[submodule "lib/matlab/snirf_homer3"]
-	path = lib/matlab/snirf_homer3
-	url = https://github.com/fNIRS/snirf_homer3.git

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The following vendors export data in SNIRF format.
 
 ## Development Information
 
+Please read the procedure for [making contributions to SNIRF](CONTRIBUTING.md).
+
 To download the latest specification document alone click on this
 [download link](https://github.com/fNIRS/snirf/archive/master.zip),
 or use the below command
@@ -69,7 +71,6 @@ file in each package for instructions on how to use.
 | sample data    | https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/master.zip   |
 | EasyH5 Toolbox | https://github.com/fangq/easyh5/archive/v0.8.tar.gz       |
 | JSNIRF Toolbox | https://github.com/fangq/jsnirfy/archive/v0.4.tar.gz      |
-| SNIRF_HOMER3   | https://github.com/fNIRS/snirf_homer3/archive/master.zip  |
 
 [This page](https://github.com/BUNPC/Homer3/wiki/Standalone-SNIRF-loading-and-saving)
 provides examples of how to work with SNIRF files using the

--- a/lib/matlab/README.md
+++ b/lib/matlab/README.md
@@ -11,7 +11,6 @@ in the below sections.
 
 - [General instructions](#general-instructions)
 - [EasyH5 HDF5/SNIRF Parser](#easyh5-hdf5snirf-parser)
-- [HOMER3 SNIRF Parser](#homer3-snirf-parser)
 - [JSNIRF Toolbox](#jsnirf-toolbox)
 
 General instructions
@@ -69,37 +68,6 @@ Saving SNIRF file:
 ```
   saveh5(data_raw, 'datafile.snirf','rootname','');   % data_raw must be a snirf structure containing {'formatVersion','nirs'} subfield
   saveh5(data_raw, 'datafile_zlib.snirf',,'rootname','','compression','deflate'); % use 'compression' flag to save data with compression to save space
-```
-
-
-HOMER3 SNIRF Parser
---------------------
-* Folder: `snirf_homer3`
-* Author: Jay Dubb <jdubb at bu.edu>
-* Version: 1.13.4
-
-### How to install
-Following the above general instruction, and run the below command in MATLAB to use
-this toolbox:
-
-```
-  cd snirf_homer3
-  addpath(genpath(pwd))
-```
-
-alternatively, you can use 
-```
-  cd /path/to/snirf_homer3/
-  setpaths
-```
-### How to use
-Loading SNIRF file:
-```
-  %% to be added
-```
-Saving SNIRF file:
-```
-  %% to be added
 ```
 
 JSNIRF Toolbox


### PR DESCRIPTION
We have not been maintaining snirf_homer3, we really only maintain the SNIRF interface now at https://github.com/BUNPC/DataTree. smonterohdz highlighted some breaking inconsistencies there.

There is still a link to instructions on how to work with SNIRF files using Homer3, which is the supported approach.