### PR TITLE
Define some supported aux channel names

### DIFF
--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -219,3 +219,9 @@ Wabnitz
 al
 et
 DTOF
+accel
+magn
+ACCEL
+Accelerometer
+Gyrometer
+MAGN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Remove sourcePos, detectorPos, and landmarkPos
 * Add wavelengthActual and wavelengthEmissionActual
 * Change stim/data names from attribute to regular dataset
+* Add list of supported aux name values including accel, gyro, magn
 
 
 ### `1.0 - Draft 3` (November 11 2019)

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -916,6 +916,21 @@ This variable specifies the offset of the file time origin relative to absolute
 |"HRF BFi"  | Hemodynamic response function for blood flow index               |
 
 
+### Supported `/nirs(i)/aux(j)/name` values
+
+| Tag Name  |                           Meanings                               |
+|-----------|------------------------------------------------------------------|
+|"ACCEL_X"  | Accelerometer data, first axis of orientation                    |
+|"ACCEL_Y"  | Accelerometer data, second axis of orientation                   |
+|"ACCEL_Z"  | Accelerometer data, third axis of orientation                    |
+|"GYRO_X"   | Gyrometer data, first axis of orientation                        |
+|"GYRO_Y"   | Gyrometer data, second axis of orientation                       |
+|"GYRO_Z"   | Gyrometer data, third axis of orientation                        |
+|"MAGN_X"   | Magnetometer data, first axis of orientation                     |
+|"MAGN_Y"   | Magnetometer data, second axis of orientation                    |
+|"MAGN_Z"   | Magnetometer data, third axis of orientation                     |
+
+
 ### Examples of stimulus waveforms
 
 Assume there are 10 time points, starting at zero, spaced 0.1s apart.  If we 


### PR DESCRIPTION
Defining some /nirs(i)/aux(j)/name values for common signals like accelerometer, gyrometers, magnetometeres. These have counterparts in BIDS.