### PR TITLE
v1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 
 ### `1.0`
 
-**This version is in development and has not been released yet**
-
 * General clarification of wording throughout the specification
 * Remove sourcePos, detectorPos, and landmarkPos
 * Add wavelengthActual and wavelengthEmissionActual

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -1,7 +1,7 @@
 Shared Near Infrared Spectroscopy Format (SNIRF) Specification
 ==============================================================
 
-* **Document Version**: v1.0 Draft 3
+* **Document Version**: v1.0
 * **License**: This document is in the public domain.
 
 ## Table of Content


### PR DESCRIPTION
Version 1.0 is here!

* General clarification of wording throughout the specification.
* Remove sourcePos, detectorPos, and landmarkPos.
* Add wavelengthActual and wavelengthEmissionActual.
* Change stim/data names from attribute to regular dataset.
* Require either 2D or 3D positions, not just 2D.
* Add list of supported aux name values including accel, gyro, magn
* Add datatypes for processed TD moment data.