### PR TITLE
Generate PDF of the SNIRF specification

### DIFF
--- a/.github/workflows/create_pdf.yml
+++ b/.github/workflows/create_pdf.yml
@@ -1,0 +1,26 @@
+name: Create PDF
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - '*'
+  workflow_dispatch:
+
+
+jobs:
+  convert_via_pandoc:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: docker://pandoc/latex:2.9
+        with:
+          args: --pdf-engine=xelatex --output=snirf.pdf snirf_specification.md
+          
+      - uses: actions/upload-artifact@master
+        with:
+          name: snirf.pdf
+          path: snirf.pdf


### PR DESCRIPTION
This PR adds a GitHub action which will automatically generate a pdf version of the specification. It will generate the pdf from the markdown file, so its always up to date. You can access the pdf file by clicking on the GitHub action `details` button.

I thought this may be handy. But its definitely not an essential feature, so don't feel obliged to accept this PR unless people think this would be useful (it was only a few minutes work for me). Is this something people want?