### PR TITLE
Generate HTML of the SNIRF specification and host on GitHub

### DIFF
--- a/.github/workflows/create_html.yml
+++ b/.github/workflows/create_html.yml
@@ -1,0 +1,43 @@
+name: Create HTML
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - '*'
+  workflow_dispatch:
+
+
+jobs:
+  convert_via_pandoc:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: create output directory
+        run: |
+          mkdir output
+          
+      - uses: docker://pandoc/core:2.9
+        with:
+          args: --output=output/index.html snirf_specification.md
+          
+      - uses: actions/upload-artifact@master
+        with:
+          name: snirf.html
+          path: output/index.html
+          
+      - name: Deploy
+#         if: ${{ github.ref == 'refs/heads/master' }}
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./output
+          publish_branch: gh-pages
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'action@github.com'
+          keep_files: false
+          commit_message: 'Update documentation'      

--- a/.github/workflows/create_html.yml
+++ b/.github/workflows/create_html.yml
@@ -30,7 +30,7 @@ jobs:
           path: output/index.html
           
       - name: Deploy
-#         if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -109,6 +109,9 @@ Note, native datatypes are defined by the build of the software (e.g.
 little/big endian) and are automatically converted by the HDF5 backend for 
 consistent read/write between OS platforms.
 
+The development of the SNIRF specification is conducted in an open manner using the GitHub
+platform. To contribute or provide feedback visit [https://github.com/fNIRS/snirf](https://github.com/fNIRS/snirf).
+
 ## SNIRF file specification
 
 The SNIRF data format must have the initial `H5G` group type `/nirs` at the 


### PR DESCRIPTION
This PR adds a GitHub action which will automatically generate a html version of the specification. It will generate the html from the markdown file, so its always up to date. It will then push the html to the GitHub pages feature, which provides free website hosting. 

You can see an example of what this will look like at https://rob-luke.github.io/snirf

It also provides html linking to specific sections incase you want to point someone to a specific point https://rob-luke.github.io/snirf/#nirsiprobedetectorpos2d

If you wish me to merge this the address would be https://fNIRS.github.io/snirf You can use custom domains if you own it.

I also added a note in the specification pointing contributors to the GitHub page.

I thought this may be handy. But its definitely not an essential feature, so don't feel obliged to accept this PR unless people think this would be useful (it was only a few minutes work for me). Is this something people want?


### Potential issue

Which version should be hosted in the html? I suggest just the latest development version as this is what people are most likely to be targeting. But it may also make sense to only update the html when a release is tagged. Im cool either way.