### PR TITLE
Post v1.0 release tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Change Log For The SNIRF File Format
 
+SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
+
+
+### `1.0.1` In development
+
+* No changes have been made yet compared to v1.0
+
 
 ### `1.0` (September 23 2021)
+
+[View this version of the specification](https://github.com/fNIRS/snirf/blob/v1.0/snirf_specification.md)  
 
 * General clarification of wording throughout the specification.
 * Remove sourcePos, detectorPos, and landmarkPos.
@@ -11,8 +20,9 @@
 * Add list of supported aux name values including accel, gyro, magn
 * Add datatypes for processed TD moment data.
 
+
 ### `1.0 - Draft 3` (November 11 2019)
 
-[View this version](https://github.com/fNIRS/snirf/tree/da550abf7ec70084e31ba428df09a9dcbf3e6036)  
+[View this version of the specification](https://github.com/fNIRS/snirf/tree/da550abf7ec70084e31ba428df09a9dcbf3e6036)  
 
 * Initial version with change log.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,8 +20,9 @@ Only someone with write access to the `fNIRS/snirf` repository can complete this
 6. Update the README.md document to reflect the new release by:
    1. Change the path of the "View the most recent release version of the format" link to reflect the tagged version.
       This will be something like https://github.com/fNIRS/snirf/blob/v1.0/snirf_specification.md
-7. Modify the specification document to indicate that it is now a development version by:
+7. Modify the repository to indicate that it is now a development version by:
    1. Increase the version number in the SNIRF specification and append the word "development" to it. E.g., `v1.1-development`.
       This ensure that people can differentiate between released versions of the draft and work-in-progress versions.
+   2. Update the changelog file by adding a link to the released version, specifying the release data, and adding the next development version.
 8. Send an email out on the mailing list via: https://mailchi.mp/89a906ec22cf/snirf
 9. Increase the version number listed on the Society for fNIRS website: https://fnirs.org/resources/software/snirf/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,6 +23,6 @@ Only someone with write access to the `fNIRS/snirf` repository can complete this
 7. Modify the repository to indicate that it is now a development version by:
    1. Increase the version number in the SNIRF specification and append the word "development" to it. E.g., `v1.1-development`.
       This ensure that people can differentiate between released versions of the draft and work-in-progress versions.
-   2. Update the changelog file by adding a link to the released version, specifying the release data, and adding the next development version.
+   2. Update the change log file by adding a link to the released version, specifying the release data, and adding the next development version.
 8. Send an email out on the mailing list via: https://mailchi.mp/89a906ec22cf/snirf
 9. Increase the version number listed on the Society for fNIRS website: https://fnirs.org/resources/software/snirf/

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -1,7 +1,7 @@
 Shared Near Infrared Spectroscopy Format (SNIRF) Specification
 ==============================================================
 
-* **Document Version**: v1.0
+* **Document Version**: v1.0.1-development
 * **License**: This document is in the public domain.
 
 ## Table of Content


### PR DESCRIPTION
I have:

* Updated the specification in the master branch of GitHub to indicate it is now the development version for 1.0.1
* Added a link to the v1.0 tagged version of the specification in the change log
* Added the above point to the release procedure for future releases
* Updated the change log with the versioning scheme and the next version label

This is just maintenance, so anyone feel free to merge, I dont think we need two reviewers.