### PR TITLE
dataUnits for aux and measurementList

### DIFF
--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -232,3 +232,4 @@ Gyrometer
 MAGN
 dataUnit
 CMIXF
+unscaled

--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -230,3 +230,5 @@ ACCEL
 Accelerometer
 Gyrometer
 MAGN
+dataUnit
+CMIXF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
 
 ### `1.0.1` In development
 
-* No changes have been made yet compared to v1.0
+* Add dataUnit to indexed groups aux and measurementList
 
 
 ### `1.0` (September 23 2021)
@@ -19,7 +19,6 @@ SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
 * Require either 2D or 3D positions, not just 2D.
 * Add list of supported aux name values including accel, gyro, magn
 * Add datatypes for processed TD moment data.
-
 
 ### `1.0 - Draft 3` (November 11 2019)
 

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -455,7 +455,7 @@ Data-type identifier. See Appendix for list possible values.
 * **Type**:  string
 * **Location**: `/nirs(i)/data(j)/measurementList(k)/dataUnit`
 
-International System of Units (SI units) identifier for the given channel. Encoding should follow the [CMIXF-12 standard](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) for maximum portability, avoiding special unicode symbols like U+03BC (μ) or U+00B5 (µ) and using '/' rather than 'per' for units such as `V/us`.
+International System of Units (SI units) identifier for the given channel. Encoding should follow the [CMIXF-12 standard](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12), avoiding special unicode symbols like U+03BC (μ) or U+00B5 (µ) and using '/' rather than 'per' for units such as `V/us`. The recommended export format is in unscaled units such as V, s, Mole.
 
 #### /nirs(i)/data(j)/measurementList(k)/dataTypeLabel 
 * **Presence**: optional
@@ -867,7 +867,7 @@ Chunked data is allowed to support real-time data streaming
 * **Type**:  string
 * **Location**: `/nirs(i)/aux(j)/dataUnit`
 
-International System of Units (SI units) identifier for the values of the auxiliary signal. Encoding should follow the [CMIXF-12 standard](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) for maximum portability, avoiding special unicode symbols like U+03BC (μ) or U+00B5 (µ) and using '/' rather than 'per' for units such as `V/us`.
+International System of Units (SI units) identifier for the given channel. Encoding should follow the [CMIXF-12 standard](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12), avoiding special unicode symbols like U+03BC (μ) or U+00B5 (µ) and using '/' rather than 'per' for units such as `V/us`. The recommended export format is in unscaled units such as V, s, Mole.
 
 #### /nirs(i)/aux(j)/time 
 * **Presence**: optional; required if `aux` is used

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -455,7 +455,7 @@ Data-type identifier. See Appendix for list possible values.
 * **Type**:  string
 * **Location**: `/nirs(i)/data(j)/measurementList(k)/dataUnit`
 
-International System of Units (SI units) identifier for the given channel. Encoding should follow the [CMIXF-12 standard](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) for maximum portability, avoiding special unicode symbols like U+03BC (μ) or U+00B5 (µ) and using '/' rather than 'per' for units `V/us`.
+International System of Units (SI units) identifier for the given channel. Encoding should follow the [CMIXF-12 standard](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) for maximum portability, avoiding special unicode symbols like U+03BC (μ) or U+00B5 (µ) and using '/' rather than 'per' for units such as `V/us`.
 
 #### /nirs(i)/data(j)/measurementList(k)/dataTypeLabel 
 * **Presence**: optional
@@ -867,7 +867,7 @@ Chunked data is allowed to support real-time data streaming
 * **Type**:  string
 * **Location**: `/nirs(i)/aux(j)/dataUnit`
 
-International System of Units (SI units) identifier for the values of the auxiliary signal. Encoding should follow the [CMIXF-12 standard](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) for maximum portability, avoiding special unicode symbols like U+03BC (μ) or U+00B5 (µ) and using '/' rather than 'per' for units `V/us`.
+International System of Units (SI units) identifier for the values of the auxiliary signal. Encoding should follow the [CMIXF-12 standard](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) for maximum portability, avoiding special unicode symbols like U+03BC (μ) or U+00B5 (µ) and using '/' rather than 'per' for units such as `V/us`.
 
 #### /nirs(i)/aux(j)/time 
 * **Presence**: optional; required if `aux` is used

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -23,6 +23,7 @@ Shared Near Infrared Spectroscopy Format (SNIRF) Specification
        * [data.measurementList.wavelengthActual](#nirsidatajmeasurementlistkwavelengthactual)
        * [data.measurementList.wavelengthEmissionActual](#nirsidatajmeasurementlistkwavelengthemissionactual)
        * [data.measurementList.dataType](#nirsidatajmeasurementlistkdatatype)
+       * [data.measurementList.dataUnit](#nirsidatajmeasurementlistkdataunit)
        * [data.measurementList.dataTypeLabel](#nirsidatajmeasurementlistkdatatypelabel)
        * [data.measurementList.dataTypeIndex](#nirsidatajmeasurementlistkdatatypeindex)
        * [data.measurementList.sourcePower](#nirsidatajmeasurementlistksourcepower)
@@ -56,6 +57,7 @@ Shared Near Infrared Spectroscopy Format (SNIRF) Specification
        * [aux](#nirsiauxj)
        * [aux.name](#nirsiauxjname)
        * [aux.dataTimeSeries](#nirsiauxjdatatimeseries)
+       * [aux.dataUnit](#nirsiauxjdataunit)
        * [aux.time](#nirsiauxjtime)
        * [aux.timeOffset](#nirsiauxjtimeoffset)
 - [Appendix](#appendix)
@@ -157,6 +159,7 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 |            `wavelengthActual`         | * Actual wavelength for a given channel      |   `<f>`        |
 |            `wavelengthEmissionActual` | * Actual emission wavelength for a channel   |   `<f>`        |
 |            `dataType`                 | * Data type for a given channel              |   `<i>`      * |
+|            `dataUnit`                 | * SI unit for a given channel                |   `"s"`        |
 |            `dataTypeLabel`            | * Data type name for a given channel         |   `"s"`        |
 |            `dataTypeIndex`            | * Data type index for a given channel        |   `<i>`      * |
 |            `sourcePower`              | * Source power for a given channel           |   `<f>`        |
@@ -190,6 +193,7 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 |     `aux{i}`                          | * Root-group for auxiliary measurements      |   `{i}`        |
 |         `name`                        | * Name of the auxiliary channel              |   `"s"`      + |
 |         `dataTimeSeries`              | * Data acquired from the auxiliary channel   | `[[<f>,...]]`+ |
+|         `dataUnit`                    | * SI unit of the auxiliary channel           |   `"s"`        |
 |         `time`                        | * Time (in `TimeUnit`) for auxiliary data    |  `[<f>,...]` + |
 |         `timeOffset`                  | * Time offset of auxiliary channel data      |  `[<f>,...]`   |
 
@@ -445,6 +449,13 @@ Actual (measured) emission wavelength in nm, if available, for the source in a g
 * **Location**: `/nirs(i)/data(j)/measurementList(k)/dataType`
 
 Data-type identifier. See Appendix for list possible values.
+
+#### /nirs(i)/data(j)/measurementList(k)/dataUnit 
+* **Presence**: optional
+* **Type**:  string
+* **Location**: `/nirs(i)/data(j)/measurementList(k)/dataUnit`
+
+International System of Units (SI units) identifier for the given channel. Encoding should follow the [CMIXF-12 standard](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) for maximum portability, avoiding special unicode symbols like U+03BC (μ) or U+00B5 (µ) and using '/' rather than 'per' for units `V/us`.
 
 #### /nirs(i)/data(j)/measurementList(k)/dataTypeLabel 
 * **Presence**: optional
@@ -850,6 +861,13 @@ This is the aux data variable. This variable has dimensions of `<number of
 time points> x 1`.
 
 Chunked data is allowed to support real-time data streaming
+
+#### /nirs(i)/aux(j)/dataUnit 
+* **Presence**: optional
+* **Type**:  string
+* **Location**: `/nirs(i)/aux(j)/dataUnit`
+
+International System of Units (SI units) identifier for the values of the auxiliary signal. Encoding should follow the [CMIXF-12 standard](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) for maximum portability, avoiding special unicode symbols like U+03BC (μ) or U+00B5 (µ) and using '/' rather than 'per' for units `V/us`.
 
 #### /nirs(i)/aux(j)/time 
 * **Presence**: optional; required if `aux` is used


### PR DESCRIPTION
Allow SI unit specification following the [CMIXF-12 standard](https://people.csail.mit.edu/jaffer/MIXF/CMIXF-12) (avoiding special unicode symbols like U+03BC (μ) or U+00B5 (µ) and using '/' rather than 'per' for units such as V/us) for `aux` data and elements of `measurementList`

Closes #91 