### PR TITLE
Typing typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
 * probe/detectorPos2D was described as `numeric` in the document when it should be `2-D array`
 
 
-
 ### `1.0` (September 23 2021)
 
 [View this version of the specification](https://github.com/fNIRS/snirf/blob/v1.0/snirf_specification.md)  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
 ### `1.0.1` In development
 
 * Add dataUnit to indexed groups aux and measurementList
+* Uses of the word "numerical" were replaced with "numeric" for consistency.
+* stim/data was incorrectly described as `[<f>,...]+` in the table when it should be `[[<f>,...]]+`
+* aux/dataTimeSeries was incorrectly described as `[[<f>,...]]+` in the table when it should be `[<f>,...]+`
+* aux/dataTimeSeries and aux/time were described as `numeric` in the document when they should be `1-D numeric array`
+* probe/detectorPos2D was described as `numeric` in the document when it should be `2-D array`
+
 
 
 ### `1.0` (September 23 2021)

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -670,7 +670,7 @@ optode in 3D. This field has size `<number of sources> x 3`.
 
 #### /nirs(i)/probe/detectorPos2D
 * **Presence**: at least one of `detectorPos2D` or `detectorPos3D` is required
-* **Type**:  numeric
+* **Type**:  numeric 2-D array
 * **Location**: `/nirs(i)/probe/detectorPos2D`
 
 Same as `probe.sourcePos2D`, but describing the detector positions in a 
@@ -854,7 +854,7 @@ This is string describing the j<sup>th</sup> auxiliary data timecourse.
 
 #### /nirs(i)/aux(j)/dataTimeSeries 
 * **Presence**: optional; required if `aux` is used
-* **Type**:  numeric
+* **Type**:  numeric 1-D array
 * **Location**: `/nirs(i)/aux(j)/dataTimeSeries`
 
 This is the aux data variable. This variable has dimensions of `<number of 
@@ -871,7 +871,7 @@ International System of Units (SI units) identifier for the given channel. Encod
 
 #### /nirs(i)/aux(j)/time 
 * **Presence**: optional; required if `aux` is used
-* **Type**:  numeric
+* **Type**:  numeric 1-D array
 * **Location**: `/nirs(i)/aux(j)/time`
 
 The time variable. This provides the acquisition time (in `TimeUnit` units) 

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -202,7 +202,7 @@ In the above table, the used notations are explained below
 * `{.}` represents a simple HDF5 group
 * `{i}` represents an HDF5 group with one or multiple sub-groups (i.e. an indexed-group)
 * `<i>` represents an integer value
-* `<f>` represents a numerical value
+* `<f>` represents a numeric value
 * `"s"` represents a string of arbitrary length
 * `[...]` represents a 1-D vector (dataset), can be empty
 * `[[...]]` represents a 2-D array (dataset), can be empty
@@ -357,7 +357,7 @@ entry
 	
 #### /nirs(i)/data(j)/dataTimeSeries 
 * **Presence**: required
-* **Type**:  numerical 2-D array
+* **Type**:  numeric 2-D array
 * **Location**: `/nirs(i)/data(j)/dataTimeSeries`
 
 This is the actual raw or processed data variable. This variable has dimensions 
@@ -373,7 +373,7 @@ Chunked data is allowed to support real-time streaming of data in this array.
 
 #### /nirs(i)/data(j)/time 
 * **Presence**: required
-* **Type**:  numerical 1-D array
+* **Type**:  numeric 1-D array
 * **Location**: `/nirs(i)/data(j)/time`
 
 The `time` variable. This provides the acquisition time of the measurement 
@@ -573,11 +573,11 @@ This is a string describing the j<sup>th</sup> stimulus condition.
 
 #### /nirs(i)/stim(j)/data 
 * **Presence**: required  as part of `stim(i)` 
-* **Type**:  numerical 2-D array
+* **Type**:  numeric 2-D array
 * **Location**: `/nirs(i)/stim(j)/data`
 * **Allowed attribute**: `names`
 
-This is a numerical 2-D array with at least 3 columns, specifying the stimulus 
+This is a numeric 2-D array with at least 3 columns, specifying the stimulus 
 time course for the j<sup>th</sup> condition. Each row corresponds to a 
 specific stimulus trial. The first three columns indicate `[starttime duration value]`.  
 The starttime, in seconds, is the time relative to the time origin when the 
@@ -609,7 +609,7 @@ geometry.  This variable has a number of required fields.
 
 #### /nirs(i)/probe/wavelengths 
 * **Presence**: required 
-* **Type**:  numerical 1-D array
+* **Type**:  numeric 1-D array
 * **Location**: `/nirs(i)/probe/wavelengths`
 
 This field describes the "nominal" wavelengths used (in `nm` unit).  This is indexed by the 
@@ -634,7 +634,7 @@ data are processed data (`dataType=99999`, see Appendix).
 
 #### /nirs(i)/probe/wavelengthsEmission 
 * **Presence**: optional 
-* **Type**:  numerical 1-D array
+* **Type**:  numeric 1-D array
 * **Location**: `/nirs(i)/probe/wavelengthsEmission`
 
 This field is required only for fluorescence data types, and describes the 

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -202,7 +202,7 @@ In the above table, the used notations are explained below
 * `{.}` represents a simple HDF5 group
 * `{i}` represents an HDF5 group with one or multiple sub-groups (i.e. an indexed-group)
 * `<i>` represents an integer value
-* `<f>` represents an numerical value
+* `<f>` represents a numerical value
 * `"s"` represents a string of arbitrary length
 * `[...]` represents a 1-D vector (dataset), can be empty
 * `[[...]]` represents a 2-D array (dataset), can be empty

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -169,7 +169,7 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 |            `detectorModuleIndex`      | * Index of the detector's parent module      |   `<i>`        |
 |     `stim{i}`                         | * Root-group for stimulus measurements       |   `{i}`        |
 |         `name`                        | * Name of the stimulus data                  |   `"s"`      + |
-|         `data`                        | * Data stream of the stimulus channel        |  `[<f>,...]` + |
+|         `data`                        | * Data stream of the stimulus channel        | `[[<f>,...]]` +|
 |         `dataLabels`                  | * Names of additional columns of stim data   |  `["s",...]`   |
 |     `probe`                           | * Root group for NIRS probe information      |   `{.}`      * |
 |         `wavelengths`                 | * List of wavelengths (in nm)                |  `[<f>,...]` * |
@@ -192,7 +192,7 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 |         `useLocalIndex`               | * If source/detector index is within a module|   `<i>`        |
 |     `aux{i}`                          | * Root-group for auxiliary measurements      |   `{i}`        |
 |         `name`                        | * Name of the auxiliary channel              |   `"s"`      + |
-|         `dataTimeSeries`              | * Data acquired from the auxiliary channel   | `[[<f>,...]]`+ |
+|         `dataTimeSeries`              | * Data acquired from the auxiliary channel   |  `[<f>,...]` + |
 |         `dataUnit`                    | * SI unit of the auxiliary channel           |   `"s"`        |
 |         `time`                        | * Time (in `TimeUnit`) for auxiliary data    |  `[<f>,...]` + |
 |         `timeOffset`                  | * Time offset of auxiliary channel data      |  `[<f>,...]`   |


### PR DESCRIPTION
This change fixes several subtle issues I came across when trying to programmatically parse the spec document.

A style change: uses of the word "numerical" were replaced with "numeric" for consistency.

1. stim/data was incorrectly described as `[<f>,...]`+ in the table when it should have been `[[<f>,...]]`+, stim data is a 2D array with each row representing a stim mark/event marker onset, duration, amplitude, etc etc
2. aux/dataTimeSeries was incorrectly described as `[[<f>,...]]`+ in the table when it should have been  `[<f>,...]`+, aux data is a single vector of data points
3. aux/dataTimeSeries and aux/time were described as `numeric` in the document when they should read `1-D numeric array`
4. probe/detectorPos2D was described as `numeric` in the document when it should read `2-D array`