### PR TITLE
Add coordinateSystem fields

### DIFF
--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -233,3 +233,10 @@ MAGN
 dataUnit
 CMIXF
 unscaled
+coordinateSystem
+CapTrak
+MNI
+NLin
+bAsym
+defition
+coordinateSystemDescription

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -846,6 +846,7 @@ for detailed descriptions of different coordinate systems.
 Free-form text description of the coordinate system.
 May also include a link to a documentation page or
 paper describing the system in greater detail.
+This field is required if the `coordinateSystem` field is set to "Other".
 
 
 #### /nirs(i)/probe/useLocalIndex 

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -823,6 +823,31 @@ associate the given landmark to a specific source or detector. All strings are
 ASCII encoded char arrays.
 
 
+#### /nirs(i)/probe/coordinateSystem(j) 
+* **Presence**: optional 
+* **Type**:  string array
+* **Location**: `/nirs(i)/probe/coordinateSystem(j)`
+
+Defines the coordinate system for sensor positions.
+The string must be one of the coordinate systems listed in the
+[BIDS specification (Appendix VII)](https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html#standard-template-identifiers)
+such as "MNI152NLin2009bAsym", "CapTrak" or "Other".
+If the value "Other" is specified, then a defition of the coordinate
+system must be provided in `/nirs(i)/probe/coordinateSystemDescription`.
+See the [FieldTrip toolbox web page](https://www.fieldtriptoolbox.org/faq/coordsys/)
+for detailed descriptions of different coordinate systems.
+
+
+#### /nirs(i)/probe/coordinateSystemDescription(j) 
+* **Presence**: optional 
+* **Type**:  string array
+* **Location**: `/nirs(i)/probe/coordinateSystemDescription(j)`
+
+Free-form text description of the coordinate system.
+May also include a link to a documentation page or
+paper describing the system in greater detail.
+
+
 #### /nirs(i)/probe/useLocalIndex 
 * **Presence**: optional 
 * **Type**:  integer


### PR DESCRIPTION
## Background

As discussed in #89 there is ambiguity about how to interpret the `source/detectorPos3D` values in SNIRF files, a coordinate system is required to interpret the 3D values. [FieldTrip has an excellent guide to coordinate systems](https://www.fieldtriptoolbox.org/faq/coordsys/).

From the FieldTrip document:

> To understand the coordinate system in which data is expressed, you should consider:
> 
> * What is the definition of the origin of the coordinate system, i.e. where is [0,0,0]?
> * In which directions are the x-, y- and z-axis pointing, i.e. is +x towards the right or towards anterior?
> * In what units are coordinates expressed, i.e. does the number “1” mean 1 meter, 1 centimeter or 1 millimeter?
> * Is the geometry scaled to some template or atlas, or does it still match the individual’s head/brain size?

fNIRS users often come from either an EEG/MEG or MRI background, and the imaging technique has similarities with both fields. So I think the following quote from the FieldTrip guide is also useful to understand the developement/differences between the available coordinate systems. 

> The coordinate systems used in EEG and MEG measurements are usually defined in terms of anatomical landmarks on the outside of the head, such as the nasion, inion and the left and right pre-auricular points...
> 
> The coordinate systems used for imaging methods such as MRI, PET and CT are usually defined in terms of internal brain structures, such as the anterior and posterior commissure. Furthermore, imaging data is sometimes scaled to a specific standard size, e.g., based on the Talairach-Tournoux atlas or one of the templates from the Montreal Neurological Institute (MNI). 

Coordinate systems are complex, as such, I have decided to propose a solution mirroring how [BIDS handles coordinate systems](https://bids-specification.readthedocs.io/en/latest/99-appendices/08-coordinate-systems.html#standard-template-identifiers). The BIDS developers have considered this issue in detail and found a solution that works for both the M/EEG and MRI community, so I think it should work for us too.

## Proposal

Add two new fields `/nirs(i)/probe/coordinateSystem` and `/nirs(i)/probe/coordinateSystemDescription`.

The `coordinateSystem` field can take any of the valid BIDS coordinate system values or "Other". If the value is "Other" them you should describe the system in `coordinateSystemDescription`.

As we already have `/nirs(i)/metaDataTags/LengthUnit`, then we do not need to mirror the BIDS field `CoordinateUnits`.


## Considerations

My understanding is that the SNIRF specification should allow for a broad range of devices from many labs including custom hardware etc. As such, I did not restrict the coordinate systems to just a subset of the EEG, MEG or fMRI specific coordinate systems. Instead, any valid BIDS coordinate system is allowed here from fMRI or from EEG which should provide maximum flexibility for labs with a more image/source space preference as well as labs with a sensor space preference. Further, including the "Other" option will allow any custom coordinate system to be used too, so long as its described in `coordinateSystemDescription`.

These fields have been set to optional presence. Ideally it would be included in all SNIRF files. However, to maintain backwards compatibility the field must be optional.

The aim here is not to align SNIRF with BIDS. But I think the BIDS team have great experience in this problem and we should build off their experience. Additionally, BIDS-fNIRS may not support all possible coordinate systems and instead restrict to a subset. But I think it is appropriate for SNIRF to have a broader range of options than BIDS permits and provide maximum flexibility for advanced users.

## Transition

I think these are the `coordinateSystem` values that existing SNIRF exporters/vendors would implement:
* NIRx: `MNI152Lin` (I am not 100 sure if this is correct, but its some form of this).
* Kernel: `MNE152NLin2009n[Sym|Asym]` ([reference](https://github.com/mne-tools/mne-python/pull/9929#discussion_r741324893))
* MNE: `CapTrak`  