### PR TITLE
Add my project pysnirf2 to the README

### DIFF
--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -233,3 +233,4 @@ MAGN
 dataUnit
 CMIXF
 unscaled
+pypi

--- a/README.md
+++ b/README.md
@@ -15,14 +15,15 @@ information on released versions is available in the [change log](CHANGELOG.md).
 
 The following software packages support reading and/or writing SNIRF files.
 
-| Software       |                   URL                        |
-|----------------|----------------------------------------------|
-| Homer2         | https://homer-fnirs.org                      |
-| Homer3         | https://github.com/BUNPC/Homer3              |
-| MNE-Python     | https://mne.tools                            |
-| NIRS-Toolbox   | https://github.com/huppertt/nirs-toolbox     |
-| FieldTrip      | https://www.fieldtriptoolbox.org             |
-| NIRStorm       | https://github.com/Nirstorm/nirstorm         |
+| Software       |Platform|                   URL                        |
+|----------------|--------|----------------------------------------------|
+| Homer2         | MATLAB | https://homer-fnirs.org                      |
+| Homer3         | MATLAB | https://github.com/BUNPC/Homer3              |
+| NIRS-Toolbox   | MATLAB | https://github.com/huppertt/nirs-toolbox     |
+| FieldTrip      | MATLAB | https://www.fieldtriptoolbox.org             |
+| NIRStorm       | MATLAB | https://github.com/Nirstorm/nirstorm         |
+| MNE-Python     | Python | https://mne.tools                            |
+| MNE-Python     | Python | https://pypi.org/project/pysnirf2/            |
 
 
 The following vendors export data in SNIRF format.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ View the most recent release version of the format: [here](https://github.com/fN
 View the development version of the format: [here](snirf_specification.md).   
 
 
+## Validating SNIRF files
+
+[pysnirf2](https://pypi.org/project/pysnirf2/) is the currently actively maintained tool for reading, writing and validating SNIRF files. pysnirf2 can be easily installed in a Python 3 environment using pip.
+
+See the [pysnirf2 README](https://github.com/BUNPC/pysnirf2#validating-a-snirf-file) for usage examples.
+
 ## User Information
 
 To browse the latest version of the SNIRF Specification document, you may click on 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following software packages support reading and/or writing SNIRF files.
 | FieldTrip      | MATLAB | https://www.fieldtriptoolbox.org             |
 | NIRStorm       | MATLAB | https://github.com/Nirstorm/nirstorm         |
 | MNE-Python     | Python | https://mne.tools                            |
-| MNE-Python     | Python | https://pypi.org/project/pysnirf2/            |
+| pysnirf2       | Python | https://pypi.org/project/pysnirf2/           |
 
 
 The following vendors export data in SNIRF format.


### PR DESCRIPTION
I have built [a Python 3 interface and validator for SNIRF files](https://pypi.org/project/pysnirf2/) inspired by the defunct but useful [pysnirf](https://github.com/bbfrederick/pysnirf) and snirf_validator projects and want to get some more users involved with it. I have added it to the table in the README along with organization by platform. Critically, it is an up-to-date validator as requested by #44