### PR TITLE
`probe/sourceLabels` is string 2-D array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
 * Added writing code samples
 * Removed ambiguity in the units of the `nirs(i)/data(j)/measurementList(k)/sourcePower` field, which were defined as both being in mW, and arbitrary. Only the latter definition is retained.
 * Changed `/nirs(i)/data(j)/time` and `/nirs(i)/aux(j)/time` to specify the variable be stored as a rank-1 array, rather than a rank-2 array with a singleton trailing dimension.
+* Specified that `probe/sourceLabels` and `probe/detectorLabels` are 2D string arrays.
   
 ### `1.0` (September 23 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
 * Added writing code samples
 * Removed ambiguity in the units of the `nirs(i)/data(j)/measurementList(k)/sourcePower` field, which were defined as both being in mW, and arbitrary. Only the latter definition is retained.
 * Changed `/nirs(i)/data(j)/time` and `/nirs(i)/aux(j)/time` to specify the variable be stored as a rank-1 array, rather than a rank-2 array with a singleton trailing dimension.
-* Specified that `probe/sourceLabels` and `probe/detectorLabels` are 2D string arrays.
+* Specified that `probe/sourceLabels` is 2D string array. In wavelength-less case, spec describes 2nd dimension of 1
   
 ### `1.0` (September 23 2021)
 

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -188,7 +188,7 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 |         `momentOrders`                | * Moment orders of the moment TD data        |  `[<f>,...]`   |
 |         `correlationTimeDelays`       | * Time delays for DCS measurements           |  `[<f>,...]`   |
 |         `correlationTimeDelayWidths`  | * Time delay width for DCS measurements      |  `[<f>,...]`   |
-|         `sourceLabels`                | * String arrays specifying source names      |  `["s",...]`   |
+|         `sourceLabels`                | * String arrays specifying source names      |  `[["s",...]]`   |
 |         `detectorLabels`              | * String arrays specifying detector names    |  `["s",...]`   |
 |         `landmarkPos2D`               | * Anatomical landmark 2-D positions          | `[[<f>,...]]`  |
 |         `landmarkPos3D`               | * Anatomical landmark 3-D positions          | `[[<f>,...]]`  |
@@ -764,7 +764,7 @@ of this field is paired with the indexing of `probe.correlationTimeDelays`.
 
 #### /nirs(i)/probe/sourceLabels 
 * **Presence**: optional 
-* **Type**:  string array
+* **Type**:  string 2-D array
 * **Location**: `/nirs(i)/probe/sourceLabels(j)`
 
 This is a string array providing user friendly or instrument specific labels 


### PR DESCRIPTION
This changes some lines of the document to be consistent with the written description of `sourceLabels` on #L772 and 773:

> ```This can be of size <number of sources>x 1 or <number of sources> x <number of wavelengths>.```