### PR TITLE
Remove 10-20 from landmark description

### DIFF
--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -821,8 +821,8 @@ index to the labels of the given landmark. Label names are stored in the
 
 This string array stores the names of the landmarks. The first string denotes 
 the name of the landmarks with an index of 1 in the 4th column of 
-`probe.landmark`, and so on. One can adopt the commonly used 10-20 landmark 
-names, such as "Nasion", "Inion", "Cz" etc, or use user-defined landmark 
+`probe.landmarkPos`, and so on. One can adopt the commonly used landmark 
+names, such as "Nasion", "Inion", "LPA", etc, or use user-defined landmark 
 labels. The landmark label can also use the unique source and detector labels 
 defined in `probe.sourceLabels` and `probe.detectorLabels`, respectively, to 
 associate the given landmark to a specific source or detector. All strings are 


### PR DESCRIPTION
This PR tries to clarify the terminology used in `landmarkLabels`. It is in follow up to an email between me and the BUNPC.

First, the old text referred to `probe.landmark`, which does not exist. I assume this was meant to refer to `probe.landmarkPos2D` and `probe.landmarkPos3D`, so I added `probe.landmarkPos` to refer to both 2 and 3D.

Second, I make a change to the landmarkLabels text as I believe it conflated "landmarks" and "standardized placement systems". 

Landmarks are positions on the skull that are used to guide sensor placement. E.g. Nasion, Inion, LPA, RPA
Standardized placement systems specify locations on the head to place sensors. E.g. 10-20

* Landmarks are standard points on the skull and the placement of sensors is "based on landmarks on the skull, namely the nasion (Nz), the inion (Iz), and the left and right pre-auricular points (LPA and RPA)" [1].
* "in line with the 10-20 electrode placement standard, the terms Nasion and Left/Right Pre Auricular point (LPA/RPA) are used to refer to the anatomical landmarks used to determine the electrode placement."
* "In the documentation below we refer to anatomical landmarks such as the Left Pre Auricular point (LPA) and the Right Pre Auricular point (RPA), or the left and right Helix-Tragus Junction (LHJ, RHJ)." [3]
* "The head coordinate frame is defined through the coordinates of anatomical landmarks on the subject’s head: usually the Nasion ([NAS](https://en.wikipedia.org/wiki/Nasion)), and the left and right preauricular points ([LPA](http://www.fieldtriptoolbox.org/faq/how_are_the_lpa_and_rpa_points_defined/#noqa:E501) and [RPA](http://www.fieldtriptoolbox.org/faq/how_are_the_lpa_and_rpa_points_defined/#noqa:E501))." [4]




[1] R. Oostenveld and P. Praamstra. The five percent electrode system for high-resolution EEG and ERP measurements. Clin Neurophysiol, 112:713-719, 2001.
[2] [Fieldtrip](https://www.fieldtriptoolbox.org/faq/how_should_i_report_the_positions_of_the_fiducial_points_on_the_head/)
[3] [BIDS](https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html#commonly-used-anatomical-landmarks-in-meg-eeg-and-ieeg-research)
[4] [MNE](https://mne.tools/stable/auto_tutorials/forward/20_source_alignment.html?highlight=landmark)
