### PR TITLE
Add notice that summary table is machine readable, add delimiters to MD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
 * Added writing code samples
 * Removed ambiguity in the units of the `nirs(i)/data(j)/measurementList(k)/sourcePower` field, which were defined as both being in mW, and arbitrary. Only the latter definition is retained.
 * Changed `/nirs(i)/data(j)/time` and `/nirs(i)/aux(j)/time` to specify the variable be stored as a rank-1 array, rather than a rank-2 array with a singleton trailing dimension.
+* Specified that `probe/sourceLabels` and `probe/detectorLabels` are 2D string arrays.
   
 ### `1.0` (September 23 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
 * Changed `/nirs(i)/data(j)/time` and `/nirs(i)/aux(j)/time` to specify the variable be stored as a rank-1 array, rather than a rank-2 array with a singleton trailing dimension.
 * Specified that `probe/sourceLabels` is 2D string array. In wavelength-less case, spec describes 2nd dimension of 1
 * Add language preventing `metaDataTags` sub-groups
+* Add notice that the summary table is intended to be machine-readable
   
 ### `1.0` (September 23 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
 * Added writing code samples
 * Removed ambiguity in the units of the `nirs(i)/data(j)/measurementList(k)/sourcePower` field, which were defined as both being in mW, and arbitrary. Only the latter definition is retained.
 * Changed `/nirs(i)/data(j)/time` and `/nirs(i)/aux(j)/time` to specify the variable be stored as a rank-1 array, rather than a rank-2 array with a singleton trailing dimension.
-* Specified that `probe/sourceLabels` and `probe/detectorLabels` are 2D string arrays.
+* Specified that `probe/sourceLabels` is 2D string array. In wavelength-less case, spec describes 2nd dimension of 1
   
 ### `1.0` (September 23 2021)
 

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -188,7 +188,7 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 |         `momentOrders`                | * Moment orders of the moment TD data        |  `[<f>,...]`   |
 |         `correlationTimeDelays`       | * Time delays for DCS measurements           |  `[<f>,...]`   |
 |         `correlationTimeDelayWidths`  | * Time delay width for DCS measurements      |  `[<f>,...]`   |
-|         `sourceLabels`                | * String arrays specifying source names      |  `["s",...]`   |
+|         `sourceLabels`                | * String arrays specifying source names      |  `[["s",...]]`   |
 |         `detectorLabels`              | * String arrays specifying detector names    |  `["s",...]`   |
 |         `landmarkPos2D`               | * Anatomical landmark 2-D positions          | `[[<f>,...]]`  |
 |         `landmarkPos3D`               | * Anatomical landmark 3-D positions          | `[[<f>,...]]`  |
@@ -764,7 +764,7 @@ of this field is paired with the indexing of `probe.correlationTimeDelays`.
 
 #### /nirs(i)/probe/sourceLabels 
 * **Presence**: optional 
-* **Type**:  string array
+* **Type**:  string 2-D array
 * **Location**: `/nirs(i)/probe/sourceLabels(j)`
 
 This is a string array providing user friendly or instrument specific labels 

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -141,6 +141,10 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 
 ### SNIRF data format summary
 
+Note that this table serves as machine-readable schema for the SNIRF format. Its format may not be altered.
+
+[//]: # (SCHEMA BEGIN)
+
 |  SNIRF-formatted NIRS data structure  |            Meaning of the data               |     Type       |
 |---------------------------------------|----------------------------------------------|----------------|
 | `/formatVersion`                      | * SNIRF format version                       |   `"s"`      * |
@@ -188,7 +192,7 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 |         `momentOrders`                | * Moment orders of the moment TD data        |  `[<f>,...]`   |
 |         `correlationTimeDelays`       | * Time delays for DCS measurements           |  `[<f>,...]`   |
 |         `correlationTimeDelayWidths`  | * Time delay width for DCS measurements      |  `[<f>,...]`   |
-|         `sourceLabels`                | * String arrays specifying source names      |  `[["s",...]]`   |
+|         `sourceLabels`                | * String arrays specifying source names      |  `[["s",...]]` |
 |         `detectorLabels`              | * String arrays specifying detector names    |  `["s",...]`   |
 |         `landmarkPos2D`               | * Anatomical landmark 2-D positions          | `[[<f>,...]]`  |
 |         `landmarkPos3D`               | * Anatomical landmark 3-D positions          | `[[<f>,...]]`  |
@@ -203,8 +207,9 @@ HDF5 location paths to denote the indices of sub-elements when multiplicity pres
 |         `time`                        | * Time (in `TimeUnit`) for auxiliary data    |  `[<f>,...]` + |
 |         `timeOffset`                  | * Time offset of auxiliary channel data      |  `[<f>,...]`   |
 
-In the above table, the used notations are explained below
+[//]: # (SCHEMA END)
 
+In the above schema table, the used notations are explained below:
 * `{.}` represents a simple HDF5 group
 * `{i}` represents an HDF5 group with one or multiple sub-groups (i.e. an indexed-group)
 * `<i>` represents an integer value
@@ -214,7 +219,7 @@ In the above table, the used notations are explained below
 * `[[...]]` represents a 2-D array (dataset), can be empty
 * `...` (optional) additional elements similar to the previous element
 * `*` in the last column indicates a required subfield
-* `*ⁿ` in the last column indicates that at least one of the subfields in the subgroup identified by `n` required
+* `*ⁿ` in the last column indicates that at least one of the subfields in the subgroup identified by `n` is required
 * `+` in the last column indicates a required subfield if the optional parent object is included
 
 ### SNIRF data container definitions


### PR DESCRIPTION
I am parsing the summary table to generate pysnirf2 and I want to ensure that this part of the spec is not disrupted. 

I also added some invisible delimiters to the markdown.