### PR TITLE
Add Gowerlabs to vendors with SNIRF support

### DIFF
--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -17,6 +17,9 @@ TPSF
 accelerometer
 timeDelayWidths
 dt
+Gowerlabs
+gowerlabs
+uk
 nanometers
 deoxy
 oxy

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following vendors export data in SNIRF format.
 | NIRx           | https://nirx.net                 |
 | Kernel         | https://www.kernel.com           |
 | Cortivision    | https://www.cortivision.com      |
+| Gowerlabs      | https://www.gowerlabs.co.uk      |
 
 
 ## Development Information


### PR DESCRIPTION
This is currently failing due to #123 Once that is merged I will rebase this so the tests go green. 
But @dboas @Horschig @samuelpowell can you review and approve in advance of the tests passing?