### PR TITLE
enh - add Artinis sample data to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ file in each package for instructions on how to use.
 
 | Submodule      |                               URL                         |
 |----------------|-----------------------------------------------------------|
-| sample data    | https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/master.zip   |
+| BIDS sample data | https://github.com/rob-luke/BIDS-NIRS-Tapping/archive/master.zip |
+| Artinis sample data | https://github.com/Artinis-Medical-Systems-B-V/snirf_data_example |
 | EasyH5 Toolbox | https://github.com/fangq/easyh5/archive/v0.8.tar.gz       |
 | JSNIRF Toolbox | https://github.com/fangq/jsnirfy/archive/v0.4.tar.gz      |
 


### PR DESCRIPTION
We have created a repository with example data including scripts on how to analyze (using Homer3 files). Imho it would be useful to have these added to the general readme. Feel free to discuss.