### PR TITLE
Remove incomplete local channel indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,6 @@ SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
 * Added language preventing `metaDataTags` sub-groups
 * Added notice that the summary table is intended to be machine-readable
 * Removed local channel indexing owing to incomplete specification.
-
-The implementation did not define a mapping from local to global indices, and was thus incomplete.
   
 ### `v1.0` (September 23 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ SNIRF uses the [Semantic Versioning](https://semver.org) scheme.
 * Specified that `aux{i}/dataTimeSeris` is a 2D array. Multiple channels of data can be present, otherwise 2nd dimension should be 1.
 * Added language preventing `metaDataTags` sub-groups
 * Added notice that the summary table is intended to be machine-readable
+* Removed local channel indexing owing to incomplete specification.
+
+The implementation did not define a mapping from local to global indices, and was thus incomplete.
   
 ### `v1.0` (September 23 2021)
 

--- a/snirf_specification.md
+++ b/snirf_specification.md
@@ -30,9 +30,6 @@ Shared Near Infrared Spectroscopy Format (SNIRF) Specification
        * [data.measurementList.dataTypeIndex](#nirsidatajmeasurementlistkdatatypeindex)
        * [data.measurementList.sourcePower](#nirsidatajmeasurementlistksourcepower)
        * [data.measurementList.detectorGain](#nirsidatajmeasurementlistkdetectorgain)
-       * [data.measurementList.moduleIndex](#nirsidatajmeasurementlistkmoduleindex)
-       * [data.measurementList.sourceModuleIndex](#nirsidatajmeasurementlistksourcemoduleindex)
-       * [data.measurementList.detectorModuleIndex](#nirsidatajmeasurementlistkdetectormoduleindex)
        * [stim](#nirsistimj)
        * [stim.name](#nirsistimjname)
        * [stim.data](#nirsistimjdata)
@@ -57,7 +54,6 @@ Shared Near Infrared Spectroscopy Format (SNIRF) Specification
        * [probe.landmarkLabels](#nirsiprobelandmarklabelsj)
        * [probe.CoordinateSystem](#nirsiprobecoordinatesystem)
        * [probe.CoordinateSystemDescription](#nirsiprobecoordinatesystemdescription)
-       * [probe.useLocalIndex](#nirsiprobeuselocalindex)
        * [aux](#nirsiauxj)
        * [aux.name](#nirsiauxjname)
        * [aux.dataTimeSeries](#nirsiauxjdatatimeseries)
@@ -174,9 +170,6 @@ Note that this table serves as machine-readable schema for the SNIRF format. Its
 |            `dataTypeIndex`            | * Data type index for a given channel        |   `<i>`      * |
 |            `sourcePower`              | * Source power for a given channel           |   `<f>`        |
 |            `detectorGain`             | * Detector gain for a given channel          |   `<f>`        |
-|            `moduleIndex`              | * Index of the parent module (if modular)    |   `<i>`        |
-|            `sourceModuleIndex`        | * Index of the source's parent module        |   `<i>`        |
-|            `detectorModuleIndex`      | * Index of the detector's parent module      |   `<i>`        |
 |     `stim{i}`                         | * Root-group for stimulus measurements       |   `{i}`        |
 |         `name`                        | * Name of the stimulus data                  |   `"s"`      + |
 |         `data`                        | * Data stream of the stimulus channel        | `[[<f>,...]]` +|
@@ -201,7 +194,6 @@ Note that this table serves as machine-readable schema for the SNIRF format. Its
 |         `landmarkLabels`              | * String arrays specifying landmark names    |  `["s",...]`   |
 |         `coordinateSystem`            | * Coordinate system used in probe description|   `"s"`        |
 |         `coordinateSystemDescription` | * Description of coordinate system           |   `"s"`        |
-|         `useLocalIndex`               | * If source/detector index is within a module|   `<i>`        |
 |     `aux{i}`                          | * Root-group for auxiliary measurements      |   `{i}`        |
 |         `name`                        | * Name of the auxiliary channel              |   `"s"`      + |
 |         `dataTimeSeries`              | * Data acquired from the auxiliary channel   | `[[<f>,...]]` +|
@@ -513,39 +505,6 @@ The units are not defined, unless the user takes the option of using a `metaData
 * **Location**: `/nirs(i)/data(j)/measurementList(k)/detectorGain`
 
 Detector gain
-
-#### /nirs(i)/data(j)/measurementList(k)/moduleIndex 
-* **Presence**: optional
-* **Type**:  integer
-* **Location**: `/nirs(i)/data(j)/measurementList(k)/moduleIndex`
-
-Index of a repeating module. If `moduleIndex` is provided while `useLocalIndex`
-is set to `true`, then, both `measurementList(k).sourceIndex` and 
-`measurementList(k).detectorIndex` are assumed to be the local indices
-of the same module specified by `moduleIndex`. If the source and
-detector are located on different modules, one must use `sourceModuleIndex`
-and `detectorModuleIndex` instead to specify separate parent module 
-indices. See below.
-
-
-#### /nirs(i)/data(j)/measurementList(k)/sourceModuleIndex 
-* **Presence**: optional
-* **Type**:  integer
-* **Location**: `/nirs(i)/data(j)/measurementList(k)/sourceModuleIndex`
-
-Index of the module that contains the source of the channel. 
-This index must be used together with `detectorModuleIndex`, and 
-can not be used when `moduleIndex` presents.
-
-#### /nirs(i)/data(j)/measurementList(k)/detectorModuleIndex 
-* **Presence**: optional
-* **Type**:  integer
-* **Location**: `/nirs(i)/data(j)/measurementList(k)/detectorModuleIndex`
-
-Index of the module that contains the detector of the channel. 
-This index must be used together with `sourceModuleIndex`, and 
-can not be used when `moduleIndex` presents.
-
 
 For example, if `measurementList5` is a structure with `sourceIndex=2`, 
 `detectorIndex=3`, `wavelengthIndex=1`, `dataType=1`, `dataTypeIndex=1` would 
@@ -873,20 +832,6 @@ Free-form text description of the coordinate system.
 May also include a link to a documentation page or
 paper describing the system in greater detail.
 This field is required if the `coordinateSystem` field is set to "Other".
-
-
-#### /nirs(i)/probe/useLocalIndex 
-* **Presence**: optional 
-* **Type**:  integer
-* **Location**: `/nirs(i)/probe/useLocalIndex`
-
-For modular NIRS systems, setting this flag to a non-zero integer indicates 
-that `measurementList(k).sourceIndex` and `measurementList(k).detectorIndex` 
-are module-specific local-indices. One must also include 
-`measurementList(k).moduleIndex`, or when cross-module channels present, both 
-`measurementList(k).sourceModuleIndex` and `measurementList(k).detectorModuleIndex` 
-in the `measurementList` structure in order to restore the global indices 
-of the sources/detectors.
 
 
 #### /nirs(i)/aux(j) 


### PR DESCRIPTION
The current implementation of local channel indexing is incomplete, because there is no defined mapping from local indices to global indices.

We further note that all practical purposes (e.g. analysis) a global index is required.

It is recognised that local indices do provide additional information. For example, there may be differing noise characteristics in the data which are dependent upon the local indices. However, capturing this information by means of indexing is vendor specific, and exploitation requires an intimate knowledge of the system. 

If it is decided that such information should be retained, this should be done in a vendor agnostic and explicit manner. For example, in the case of noise characteristics, a per-channel noise distribution could be specified. But more generally, further design is required to understand how to most flexibilty translate the qualities of the acquistion system to the analysis phase, consider e.g., #141.

Thus, on balance, it has been decided to remove the current local indexing implementation. 

We believe that the lack of specificaion of a mapping from local to global indexing means that it is not possible to have produced a compliant SNIRF file using local indexing, and hence this change is non-breaking. 

Fix #106.