### PR TITLE
add OBELAB to supported vendors

### DIFF
--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -289,3 +289,4 @@ IBS
 Kura
 Middell
 Sreekanth
+obelab

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following vendors export data in SNIRF format.
 | Cortivision    | https://www.cortivision.com      |
 | Gowerlabs      | https://www.gowerlabs.co.uk      |
 | Artinis        | https://www.artinis.com          |
+| OBELAB         | https://www.obelab.com           |
 
 
 ## Governance


### PR DESCRIPTION
Dear Collaborators,

We have recently released measurement tool and analysis tool fully compatible to snirf format using NIRSIT system. 

I added OBELAB as a vendor supporting snirf data format.

If there's further information needed, I am happy support.